### PR TITLE
ci: remove building service on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,15 +56,16 @@ jobs:
 workflows:
   go-service-template:
     jobs:
-      - build-service
+      - build-service:
+          filters:
+              branches:
+                ignore: master
       - build-docker:
           filters:
               branches:
                 ignore: master
       - release:
           context: gh
-          requires:
-            - build-service
           filters:
             branches:
               only: master


### PR DESCRIPTION
The reason for this is that we will make it mandatory to have up to date branches and master can focus release