### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.351.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.19.1
-	github.com/alexfalkowski/go-service/v2 v2.349.0
+	github.com/alexfalkowski/go-service/v2 v2.351.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.19.1 h1:LS58hHOq3CbMFMf0DNp09t2AzDW0/H4TZ9KoXXxTQgo=
 github.com/alexfalkowski/go-health/v2 v2.19.1/go.mod h1:ypy+lqZpEh2HPNLqaDAv6wJBbxuouOZoPkkrtrMNXrA=
-github.com/alexfalkowski/go-service/v2 v2.349.0 h1:k3GLu4o0x5IpYltyTL6jIjA9UD7JGW0XdIhDHrEPdQE=
-github.com/alexfalkowski/go-service/v2 v2.349.0/go.mod h1:JWavyYKktE4NJgI7APCsHctzsAU4+mCXMsOXeOrmDkA=
+github.com/alexfalkowski/go-service/v2 v2.351.0 h1:R1MGghZO+MDkqWIOsICLA9tzx94ZU90pBy3BFvwdj34=
+github.com/alexfalkowski/go-service/v2 v2.351.0/go.mod h1:JWavyYKktE4NJgI7APCsHctzsAU4+mCXMsOXeOrmDkA=
 github.com/alexfalkowski/go-sync v1.21.0 h1:Aydt3mB0FwmaRPjDsO4ZHJIa0HdueTwRt0i4NQtNvsA=
 github.com/alexfalkowski/go-sync v1.21.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     benchmark-malloc (0.2.0)
     benchmark-perf (0.6.0)
     benchmark-trend (0.4.0)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     builder (3.3.0)
     concurrent-ruby (1.3.6)
     config (5.6.1)
@@ -60,9 +60,9 @@ GEM
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     http-accept (1.7.0)
-    http-cookie (1.1.4)
+    http-cookie (1.1.6)
       domain_name (~> 0.5)
-    json (2.19.3)
+    json (2.19.4)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -76,7 +76,7 @@ GEM
     mustermann (3.1.1)
     netrc (0.11.0)
     nio4r (2.7.5)
-    nonnative (2.13.0)
+    nonnative (2.13.1)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)
@@ -91,7 +91,7 @@ GEM
       rspec-wait (>= 1, < 2)
       sinatra (>= 4, < 5)
     ostruct (0.6.3)
-    parallel (2.0.1)
+    parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
@@ -186,4 +186,4 @@ DEPENDENCIES
   ruby-lsp
 
 BUNDLED WITH
-  4.0.8
+  4.0.10


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.351.0
