### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.574.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.28.0
-	github.com/alexfalkowski/go-service/v2 v2.573.0
+	github.com/alexfalkowski/go-service/v2 v2.574.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.28.0 h1:m8joTG7hrUfPZCzlaW8y6ZkDaxro95frteIvydXjfWE=
 github.com/alexfalkowski/go-health/v2 v2.28.0/go.mod h1:oIzLvkIhiXUbPSYQRW2Gezah+sW+ZEY9BcoOi/5Agxo=
-github.com/alexfalkowski/go-service/v2 v2.573.0 h1:Upnbau2rv2XvUQJN0C5kpClhjYB4qNDghPtX/RKENNA=
-github.com/alexfalkowski/go-service/v2 v2.573.0/go.mod h1:ZZvCXaz+mv3JTAjZMdEw0DeKz8x6iMfg91SKBa+3NE4=
+github.com/alexfalkowski/go-service/v2 v2.574.0 h1:ctnap31q5IfgEk709A+3mOmYIAcuBbV68VH5FBqAbYI=
+github.com/alexfalkowski/go-service/v2 v2.574.0/go.mod h1:ZZvCXaz+mv3JTAjZMdEw0DeKz8x6iMfg91SKBa+3NE4=
 github.com/alexfalkowski/go-sync v1.24.0 h1:CrV+LITc8C78v01u9ATGvIgipmNtJlZWGWW1znFsdjM=
 github.com/alexfalkowski/go-sync v1.24.0/go.mod h1:2vmRtpHHSoGPIiXJ7j3lm0GK2SI32XbYvvrjrZ+eo/k=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.1.6)
       domain_name (~> 0.5)
-    json (2.19.8)
+    json (2.19.9)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.574.0
