### PR TITLE
test(features): name cucumber html reports by run

### DIFF
--- a/test/.config/cucumber.yml
+++ b/test/.config/cucumber.yml
@@ -1,1 +1,1 @@
-report: --format junit --out reports --format html --out reports/index.html --format pretty --publish-quiet
+report: --format junit --out reports --format html --out reports/<%= ENV.fetch("COVERAGE_NAME", "index") %>.html --format pretty --publish-quiet


### PR DESCRIPTION
What:
- Update the Cucumber report profile to derive the HTML output path from COVERAGE_NAME.
- Keep JUnit XML and pretty formatter output unchanged.
- Preserve reports/index.html as the fallback when COVERAGE_NAME is not set.

Why:
- Prevent benchmark runs from overwriting feature-run HTML reports.
- Align this repo with the shared bin guidance for durable Cucumber HTML artifacts.

Testing:
- zsh -lic 'make ruby-lint'
- git diff --check
