### PR TITLE
build(project): check protobuf api freshness in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,8 @@ jobs:
           key: go-service-template-go-lint-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-lint-version" }}-{{ checksum ".source-key" }}
           paths:
             - ~/.cache/golangci-lint
+      - run: make proto-breaking
+      - run: make proto-stale
       - run: make sec
       - run: make features
       - run: make benchmarks


### PR DESCRIPTION
## What

- Add protobuf breaking-change and stale-output checks to the CircleCI build job.
- Keep the checks in the same validation sequence as sibling gRPC service repositories.

## Why

- The template owns a first-class protobuf API and commits generated Go and Ruby outputs.
- Running the existing shared checks in CI catches stale generated files and API compatibility breaks before feature and benchmark validation.

## Testing

- `gmake -n proto-breaking proto-stale` - passed and showed the expected Buf commands.
- `gmake -C api generate` - passed.
- `git diff --exit-code -- api test/lib` - passed.
- `gmake proto-breaking` - passed with network access to the remote master baseline.
