### PR TITLE
docs(agents): show help for nested make defaults

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -1,1 +1,2 @@
+include ../bin/build/make/help.mak
 include ../bin/build/make/buf.mak

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,1 +1,2 @@
+include ../bin/build/make/help.mak
 include ../bin/build/make/ruby.mak


### PR DESCRIPTION
Include the shared help target before nested API and test make fragments.
