### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.638.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.33.0
-	github.com/alexfalkowski/go-service/v2 v2.636.0
+	github.com/alexfalkowski/go-service/v2 v2.638.0
 	google.golang.org/grpc v1.82.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.33.0 h1:25fFPDnuIhZjLP1FYvzTayOMpwyjppzaxBXj/TPmkM4=
 github.com/alexfalkowski/go-health/v2 v2.33.0/go.mod h1:H11y8kNp0Ks3ayUNwjPOAV4314lGeH8MuwolYV+6l0M=
-github.com/alexfalkowski/go-service/v2 v2.636.0 h1:k6eJ8Ko03d1+3qTASnPNeYTMbkbqsc0aCoBSb4C8hnE=
-github.com/alexfalkowski/go-service/v2 v2.636.0/go.mod h1:X8aeA3w+M9k1ZYGGaLHuwB78zgYrBlA42BUE6bES7+w=
+github.com/alexfalkowski/go-service/v2 v2.638.0 h1:+m/kcRKZWLTra0qxjywnE2djTeLXqPkKYI/ykeyUvBY=
+github.com/alexfalkowski/go-service/v2 v2.638.0/go.mod h1:X8aeA3w+M9k1ZYGGaLHuwB78zgYrBlA42BUE6bES7+w=
 github.com/alexfalkowski/go-sync v1.27.0 h1:Mnk9mhspHt/NzMwFvTyikAla1QF3GDufzuA1v8zvdcY=
 github.com/alexfalkowski/go-sync v1.27.0/go.mod h1:2vmRtpHHSoGPIiXJ7j3lm0GK2SI32XbYvvrjrZ+eo/k=
 github.com/arl/statsviz v0.8.0 h1:O6GjjVxEDxcByAucOSl29HaGYLXsuwA3ujJw8H9E7/U=

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.1)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     ruby-lsp (0.26.9)


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.638.0
