### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.678.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.37.0
-	github.com/alexfalkowski/go-service/v2 v2.677.0
+	github.com/alexfalkowski/go-service/v2 v2.678.0
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.37.0 h1:UItNzlTyEafq5MoqaHpMxYqXAHzqL6Cpjb9wujPedL0=
 github.com/alexfalkowski/go-health/v2 v2.37.0/go.mod h1:t6fhN4YxTB26TSnKUjLyjZFRbKv4EkBwinWd/fFn4Us=
-github.com/alexfalkowski/go-service/v2 v2.677.0 h1:tuVPrQI1I01SFEWMxRGXrrEp2tTybo9N41z4intYJFY=
-github.com/alexfalkowski/go-service/v2 v2.677.0/go.mod h1:TdsSbz+zm/17hQhM6GTRn+he6Dwnkgdb8h8r7ft+RuI=
+github.com/alexfalkowski/go-service/v2 v2.678.0 h1:l/YmjR5UGCC2L0inXrgMh3iqzsYmhYM0dr5dpYVUvew=
+github.com/alexfalkowski/go-service/v2 v2.678.0/go.mod h1:TdsSbz+zm/17hQhM6GTRn+he6Dwnkgdb8h8r7ft+RuI=
 github.com/alexfalkowski/go-sync v1.33.0 h1:XN5XUFJ/w/emDUJ0CXZOZl6UVTkx/zj0y6kaFWIHbk8=
 github.com/alexfalkowski/go-sync v1.33.0/go.mod h1:IzEbtMNtoLHdIfoO6Z+f7azto4wjLuj6ZgAOrpKLZbY=
 github.com/arl/statsviz v0.8.1 h1:9Ns7GBWCPWn46M/KfqZ5BqRxU578e/MV7/DOwpt2Sd8=

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     mustermann (3.1.1)
     netrc (0.11.0)
     nio4r (2.7.5)
-    nonnative (3.30.0)
+    nonnative (3.32.0)
       concurrent-ruby (>= 1, < 2)
       config (>= 5, < 6)
       cucumber (>= 7, < 12)


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.678.0
