### PR TITLE
feat(deps): upgraded github.com/alexfalkowski/go-service/v2 to v2.730.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/alexfalkowski/go-health/v2 v2.37.0
-	github.com/alexfalkowski/go-service/v2 v2.729.0
+	github.com/alexfalkowski/go-service/v2 v2.730.0
 	google.golang.org/grpc v1.83.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1 h1:+JkXLHME8vLJafGhOH4ao
 github.com/aead/cmac v0.0.0-20160719120800-7af84192f0b1/go.mod h1:nuudZmJhzWtx2212z+pkuy7B6nkBqa+xwNXZHL1j8cg=
 github.com/alexfalkowski/go-health/v2 v2.37.0 h1:UItNzlTyEafq5MoqaHpMxYqXAHzqL6Cpjb9wujPedL0=
 github.com/alexfalkowski/go-health/v2 v2.37.0/go.mod h1:t6fhN4YxTB26TSnKUjLyjZFRbKv4EkBwinWd/fFn4Us=
-github.com/alexfalkowski/go-service/v2 v2.729.0 h1:i4yK/enogW0M2UyPd5G0H9MHGlCIrN2vrOKqoFwCy3Q=
-github.com/alexfalkowski/go-service/v2 v2.729.0/go.mod h1:7txB0JZ7dBk4t8BmSvzBEgYC9LhqXKaSKSFz0cw6u74=
+github.com/alexfalkowski/go-service/v2 v2.730.0 h1:EQxqus+EbLAomNHed6dTmejUY18ZxHSKwiy0e79oCN8=
+github.com/alexfalkowski/go-service/v2 v2.730.0/go.mod h1:7txB0JZ7dBk4t8BmSvzBEgYC9LhqXKaSKSFz0cw6u74=
 github.com/alexfalkowski/go-sync v1.33.0 h1:XN5XUFJ/w/emDUJ0CXZOZl6UVTkx/zj0y6kaFWIHbk8=
 github.com/alexfalkowski/go-sync v1.33.0/go.mod h1:IzEbtMNtoLHdIfoO6Z+f7azto4wjLuj6ZgAOrpKLZbY=
 github.com/arl/statsviz v0.8.1 h1:9Ns7GBWCPWn46M/KfqZ5BqRxU578e/MV7/DOwpt2Sd8=

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -195,7 +195,7 @@ GEM
       rack-protection (= 4.2.1)
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
-    sorbet-runtime (0.6.13412)
+    sorbet-runtime (0.6.13420)
     ssh_data (1.3.0)
     sys-uname (1.5.1)
       ffi (~> 1.1)


### PR DESCRIPTION
https://github.com/alexfalkowski/go-service/releases/tag/v2.730.0
